### PR TITLE
feat: rns contenthash redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   },
   "homepage": "https://github.com/bguiz/rns-link-server#readme",
   "dependencies": {
+    "@rsksmart/rns": "1.9.0",
     "express": "4.17.1",
-    "vhost": "3.0.2"
+    "vhost": "3.0.2",
+    "web3": "1.2.11"
   },
   "devDependencies": {
     "node-dev": "6.2.0"

--- a/server.js
+++ b/server.js
@@ -1,5 +1,33 @@
 const express = require('express');
 const vhost = require('vhost');
+const Web3 = require('web3');
+const RNS = require('@rsksmart/rns');
+
+const rpcUrl = process.env.RPC_URL ||
+  'https://public-node.rsk.co/';
+// Ref: https://developers.rsk.co/rif/rns/architecture/registry/
+const rnsRegistryAddress = process.env.RNS_REGISTRY_ADDRESS ||
+  '0xcb868aeabd31e2b66f74e9a55cf064abb31a4ad5';
+// Ref: https://developers.rsk.co/rif/rns/architecture/definitive-resolver/
+const rnsResolverAddress = process.env.RNS_RESOLVER_ADDRESS ||
+  '0xD87f8121D44F3717d4bAdC50b24E50044f86D64B';
+const rnsChainId = process.env.RNS_CHAIN_ID ||
+  31;
+
+// Ref: https://developers.rsk.co/rif/rns/libs/javascript/Advanced-usage/
+const web3 = new Web3(rpcUrl);
+const rns = new RNS(web3);
+// TODO figure out if custom initialisation is necessary
+// const rns = new RNS(
+//   web3,
+//   {
+//     contractAddresses: {
+//       // registry: rnsRegistryAddress.toLowerCase(),
+//       // resolver: rnsResolverAddress.toLowerCase(),
+//     },
+//     networkId: rnsChainId,
+//   }
+// );
 
 const server = express();
 


### PR DESCRIPTION
## What 

- query domain name to obtain `contenthash` and `addr`
- if `contenthash` is set, redirect to it (ipfs only for now)
- add web3 and rns.js as deps

## Why

- core feature of this project!