### PR TITLE
feat: cache contenthashes using in-memory LRU cache

### DIFF
--- a/lru-cache-memory.js
+++ b/lru-cache-memory.js
@@ -1,0 +1,29 @@
+const lruCache = require('lru-cache');
+
+const cacheMaxItems = process.env.CACHE_MAX ||
+  2048; // maximum item count before dropping
+const cacheTtl = process.env.CACHE_TTL ||
+  (24 * 60); // in minutes, default to a day
+
+const lruCacheOptions = {
+  max: 2048,
+  maxAge: (cacheTtl * 60e3),
+};
+
+const cache = new lruCache(lruCacheOptions);
+
+module.exports = cache;
+
+// TODO note that `maxAge` based cache invalidation
+// is intended only as a crude first cut approach.
+// Cache invalidation strategies to consider:
+//
+// 1. Reply instantly using cached value,and
+//    and query new value as a background task
+// 2. Set up listeners over web sockets (using web3.js)
+//    on the various RNS resolvers which support contenthash
+//    an invalidate relevant address upon each event received
+
+// TODO set up persistent cache (like redis) to allow
+// sharing between multiple load-balanced instances
+// of this server

--- a/lru-cache-memory.js
+++ b/lru-cache-memory.js
@@ -6,7 +6,7 @@ const cacheTtl = process.env.CACHE_TTL ||
   (24 * 60); // in minutes, default to a day
 
 const lruCacheOptions = {
-  max: 2048,
+  max: cacheMaxItems,
   maxAge: (cacheTtl * 60e3),
 };
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@rsksmart/rns": "1.9.0",
     "express": "4.17.1",
+    "lru-cache": "6.0.0",
     "vhost": "3.0.2",
     "web3": "1.2.11"
   },


### PR DESCRIPTION
## What

- uses in-memory least recently used caching for domains to their contenthashes
- added dep: lru-cache

## Why

- prove concept of lookup caching  to reduce lookup time
- reduce chattiness over JSON-RPC
- note that cache-invalidation strategy impl here is crude,
  and 2x "proper" cache-invalidation strategies are detailed
  within `lru-cache-memory.js` comments for consideration

## Refs

Impact of adding caching offers an approximate 100x  speed improvement,
as seen in the commented output below.
Note that this improvement multiple is expected to decrease 
when "proper" caching is introduced due to added complexity.

```bash
# Start server - 1st try takes ~2000ms
$ time curl -X GET http://website.jesse.localhost:7111
Found. Redirecting to https://ipfs.io/ipfs/QmQhesFBhK54STdQHip2crH8QVyetSSnM5RSfmY1QCbDM7
real	0m1.979s
user	0m0.009s
sys	0m0.014s
# Same server still up - 2nd through 4th tries take ~20ms
$ time curl -X GET http://website.jesse.localhost:7111
Found. Redirecting to https://ipfs.io/ipfs/QmQhesFBhK54STdQHip2crH8QVyetSSnM5RSfmY1QCbDM7
real	0m0.014s
user	0m0.009s
sys	0m0.001s
$ time curl -X GET http://website.jesse.localhost:7111
Found. Redirecting to https://ipfs.io/ipfs/QmQhesFBhK54STdQHip2crH8QVyetSSnM5RSfmY1QCbDM7
real	0m0.029s
user	0m0.007s
sys	0m0.018s
$ time curl -X GET http://website.jesse.localhost:7111
Found. Redirecting to https://ipfs.io/ipfs/QmQhesFBhK54STdQHip2crH8QVyetSSnM5RSfmY1QCbDM7
real	0m0.013s
user	0m0.008s
sys	0m0.000s
# Restart server - 1st try takes ~2000ms once again
$ time curl -X GET http://website.jesse.localhost:7111
Found. Redirecting to https://ipfs.io/ipfs/QmQhesFBhK54STdQHip2crH8QVyetSSnM5RSfmY1QCbDM7
real	0m2.050s
user	0m0.004s
sys	0m0.008s
$
```